### PR TITLE
Convert String literals to Tensors of QubitSymbols, convert add binOp, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,63 @@ The way the dimension variable expression solver works is as follows:
     2. After we have recursed through the function's AST nodes, generate constraints based on the stored `DimExpr`s, 
     3. (Within the `solve` function) Simplify two candidate constraints and move all constant values to one side, then create a matrix representing a system of equations for our constraints and solve it, yielding values for our dimension variables.
 
+## Building the Qwerty AST
+
+The Qwerty AST utilizes [Maturin](https://github.com/PyO3/maturin), a tool that helps build and publish Python packages with native Rust extensions. It's specifically designed to bridge the gap between Rust and Python to write performance-critical parts of a Python project in Rust.
+
+### 1. Create a virtual environment
+Create and activate a virtual environment:
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+### 2. Install the Maturin library
+```bash
+pip install maturin
+```
+
+### 3. Update `Cargo.toml`
+Navigate to the `qwerty_ast` folder. In `Cargo.toml`, change the line:
+```toml
+pyo3 = { version = "0.22.2", features = ["py-clone"] }
+```
+To:
+```toml
+pyo3 = { version = "0.20", features = ["extension-module", "abi3-py310"] }
+```
+
+### 4. Modify `ast.rs` (if using the `wip/repl` branch)
+Remove `PyFrame` from line 15:
+**Before:**
+```rust
+use pyo3::types::{PyFrame, PyString, PyList};
+```
+**After:**
+```rust
+use pyo3::types::{PyString, PyList};
+```
+
+### 5. Build the Python module
+Run this from the root of the Rust crate:
+```bash
+maturin develop
+```
+
+### 6. Run the Qwerty AST
+Change to the `repl` folder and run:
+```bash
+python3
+>>> import qwerty_ast
+```
+Exit python3 using `CTRL + D` on mac, `CTRL + Z + ENTER` on windows and run the Qwerty AST by running `main.py`:
+```bash
+python main.py
+```
+Input commands to convert to tensors
+```bash
+'1'
+```
 
 
+        

--- a/qwerty_ast/Cargo.toml
+++ b/qwerty_ast/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-pyo3 = {version = "0.20", features = ["extension-module"]}
+pyo3 = {version = "0.20", features = ["extension-module", "abi3-py310"]}
 num = "0.4"
 nalgebra = "0.33.2"
 

--- a/qwerty_ast/src/ast.rs
+++ b/qwerty_ast/src/ast.rs
@@ -12,7 +12,7 @@ use crate::types::*;
 use num::complex::Complex;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyFrame, PyString, PyList};
+use pyo3::types::{PyString, PyList};
 use std::collections::{HashMap, HashSet};
 pub use crate::basis::{QubitLiteral, QubitSymbol};
 use crate::dimexpr::DimExpr::Number;

--- a/repl/convert_ast.py
+++ b/repl/convert_ast.py
@@ -7,19 +7,100 @@ import ast
 import qwerty_ast
 #################### COMMON CODE FOR BOTH @QPU AND @CLASSICAL DSLs ####################
 
+# Hard-coded 1101
+
+# def convert_to_qwerty(py_ast):
+#     print(ast.dump(py_ast, indent=4))
+#     value = unpack_ast(py_ast)
+#     if value is None or not isinstance(py_ast.body[0], ast.Expr):
+#         return "Invalid Expression: Not a qubit literal or Tensor"
+#     if value == "1101":
+#         tensor = qwerty_ast.NodeBox.new_qubit_tensor(value)
+#     else:
+#         return "Not 1101"
+#     return tensor.get_tensor()
+
+
+# General check for 0s and 1s in value
+# def convert_to_qwerty(py_ast):
+#     print(ast.dump(py_ast, indent=4))
+#     value = unpack_ast(py_ast)
+
+#     if value is None or not isinstance(py_ast.body[0], ast.Expr):
+#         return "Invalid Expression: Not a qubit literal or Tensor"
+    
+#     if (isinstance(value, str) and all(num in "01" for num in value)):
+#         tensor = qwerty_ast.NodeBox.new_qubit_tensor(value)
+#         return tensor.get_tensor()
+    
+#     return "Error: Not 1s or 0s / unsupported expression"
+
+
+# Updated check to handle binOpAdd, and allow the REPL to handle recursion
+#   """
+#   1) Check if py_ast is a valid AST and if the AST has contents
+#   2) Check if the value is an expression
+#   3) Recursively loop through AST
+#   """
+
+# global var for the case if x = '1' and is the only variable inputted
+
+
 def convert_to_qwerty(py_ast):
     print(ast.dump(py_ast, indent=4))
-    value = unpack_ast(py_ast)
-    if value is None:
-        return "Invalid Expression: Not a qubit literal or Tensor"
-    tensor = qwerty_ast.NodeBox.new_qubit_tensor(py_ast.body[0].value.value)
-    return tensor.get_tensor()
-
-def unpack_ast(ast):
+    if not isinstance(py_ast, (ast.Interactive, ast.Module, ast.Expression)):
+        return "Invalid AST"
+    
+    value = py_ast.body[0]
+    print(value)
+    if not isinstance(value, ast.Expr):
+        return "Invalid syntax; expected an expression"
+    
     try:
-        return ast.body[0].value.value
-    except AttributeError:
-        return None
+        return convert_expr(value.value)
+    except Exception as e:
+        return f"Error: {e}"
+    
+#   """
+#   1) check if the instance is a binOp, if so, check its left or right values and then perform the binOp. only sum is implemented for now
+#   2) check if the instance is a constant and return it as a tensor, return value in a tensor
+#   3) check if the input is a variable, if so get the actual value of the variable and then return the value in a tensor
+#   """
+    
+def convert_expr(node):
+    if isinstance(node, ast.Constant):
+        val = node.value
+        if isinstance(val, str) and all(num in "01" for num in val):
+            tensor = qwerty_ast.NodeBox.new_qubit_tensor(node.value)
+            print("tensor type:", type(tensor))
+            print("tensor contents:", dir(tensor))            
+            return tensor
+        else:
+            raise ValueError("Invalid character, e.g. not 1s and 0s")
+        
+    # elif isinstance(node, ast.BinOp):
+    #     left = convert_expr(node.left)
+    #     right = convert_expr(node.right)
+    #     if isinstance(node.op, ast.Add):
+    #         return qwerty_ast.NodeBox.(left, right)
+    #     else:
+    #         raise NotImplementedError("Operation is not supported, only addition for now")
+        
+    # elif isinstance(node, ast.Name):
+    #     symbol_table[node.id] = qwerty_ast.NodeBox.resolve_name(node.id)
+    #     return qwerty_ast.NodeBox.resolve_name(node.id)
+    # else:
+    #     raise NotImplementedError("Variable not supported")
+    
+
+# def unpack_ast(ast):
+#     try:
+#         return ast.body[0].value.value
+#     except AttributeError:
+#         return None
+    
+
+
 
 # def convert_ast(module: ast.Module, filename: str = '', line_offset: int = 0,
 #                 col_offset: int = 0) -> Tuple[Kernel, List[bool]]:
@@ -39,6 +120,10 @@ def unpack_ast(ast):
 #     """
 #     return convert_qpu_ast(module, filename, line_offset, col_offset)
 #
+
+
+    
+
 # class BaseVisitor:
 #     """
 #     Common Python AST visitor for both ``@classical`` and ``@qpu`` kernels.
@@ -113,7 +198,7 @@ def unpack_ast(ast):
 #     EMBED_INPLACE,
 # )
 #
-# EMBEDDING_KEYWORDS = {embedding_kind_name(e): e
+# EMBEDDING_KEYWORDS = {embedFailed to authenticate. ding_kind_name(e): e
 #                       for e in EMBEDDING_KINDS}
 #
 # RESERVED_KEYWORDS = {'id', 'discard', 'discardz', 'measure', 'flip'}


### PR DESCRIPTION
[Qwerty AST: Convert String literals to Tensors of QubitSymbols](https://github.com/gt-tinker/qwerty-rust-ast/issues/2)
[Convert add BinOp to Tensor Product](https://github.com/gt-tinker/qwerty-rust-ast/issues/3)
[Put setup steps in readme](https://github.com/gt-tinker/qwerty-rust-ast/issues/4)