### PR TITLE
Support tilt operator @ and ij basis

### DIFF
--- a/qwerty_ast/src/typecheck.rs
+++ b/qwerty_ast/src/typecheck.rs
@@ -1142,8 +1142,8 @@ fn supneg_ortho(
     bv_1a.strip_dbg() == bv_1b.strip_dbg()
         && bv_2a.strip_dbg() == bv_2b.strip_dbg()
         && basis_vectors_are_ortho(bv_1a, bv_2a)
-        && (in_phase(angle_deg_1a, angle_deg_2a) && anti_phase(angle_deg_1b, angle_deg_2b)
-            || anti_phase(angle_deg_1a, angle_deg_2a) && in_phase(angle_deg_1b, angle_deg_2b))
+        && (in_phase(angle_deg_1a, angle_deg_1b) && anti_phase(angle_deg_2a, angle_deg_2b)
+            || anti_phase(angle_deg_1a, angle_deg_1b) && in_phase(angle_deg_2a, angle_deg_2b))
 }
 
 /// Checks whether `(bv_1a + bv_2a) _|_ (bv_1b + bv_2b)` using the O-Sup
@@ -1225,22 +1225,22 @@ fn superpos_are_ortho(bv_1a: &Vector, bv_2a: &Vector, bv_1b: &Vector, bv_2b: &Ve
                 },
             ),
             (
+                _,
                 Vector::VectorTilt {
-                    q: inner_bv_1b,
-                    angle_deg: angle_deg_1b,
+                    q: inner_bv_2b,
+                    angle_deg: angle_deg_2b,
                     ..
                 },
-                _,
             ),
         ) if supneg_ortho(
             bv_1a,
             0.0,
             inner_bv_2a,
             *angle_deg_2a,
-            inner_bv_1b,
-            *angle_deg_1b,
-            bv_2b,
+            bv_1b,
             0.0,
+            inner_bv_2b,
+            *angle_deg_2b,
         ) =>
         {
             true
@@ -1262,7 +1262,7 @@ fn superpos_are_ortho(bv_1a: &Vector, bv_2a: &Vector, bv_1b: &Vector, bv_2b: &Ve
 }
 
 /// Apply the structural rules (O-Sym and O-SupShuf) to attempt
-/// `superpos_are_ortho()` with different / orderings of the superpos operands.
+/// `superpos_are_ortho()` with different orderings of the superpos operands.
 fn superpos_are_ortho_sym(
     vec_1a: &Vector,
     vec_2a: &Vector,
@@ -1277,7 +1277,6 @@ fn superpos_are_ortho_sym(
 
 /// Determine if basis vectors are orthogonal without using O-Sym
 fn basis_vectors_are_ortho_nosym(bv_1: &Vector, bv_2: &Vector) -> bool {
-    // TODO: need to canonicalize first, i.e., remove nested tensors
     match (bv_1, bv_2) {
         (Vector::ZeroVector { .. }, Vector::OneVector { .. }) => true, // O-Std
 
@@ -1315,8 +1314,11 @@ fn basis_vectors_are_ortho_nosym(bv_1: &Vector, bv_2: &Vector) -> bool {
 /// orthogonality rules. Practically, this means attempting
 /// `basis_vectors_are_ortho()` and then trying again after applying O-Sym.
 fn basis_vectors_are_ortho(bv_1: &Vector, bv_2: &Vector) -> bool {
+    let canon_bv_1 = bv_1.canonicalize();
+    let canon_bv_2 = bv_2.canonicalize();
     // O-Sym
-    basis_vectors_are_ortho_nosym(bv_1, bv_2) || basis_vectors_are_ortho_nosym(bv_2, bv_1)
+    basis_vectors_are_ortho_nosym(&canon_bv_1, &canon_bv_2)
+        || basis_vectors_are_ortho_nosym(&canon_bv_2, &canon_bv_1)
 }
 
 /// Attempts to factors the small basis from the big basis and return the

--- a/qwerty_ast/src/typecheck/test_typecheck_vec_qlit.rs
+++ b/qwerty_ast/src/typecheck/test_typecheck_vec_qlit.rs
@@ -140,17 +140,17 @@ fn test_qlits_are_ortho_sym() {
         }
     ));
 
-    // '0'@45 + '1'@225 _|_ '0'@135 + '1'@135
+    // '0'@0 + '1'@90 _|_ '0'@0 + '1'@270
     assert!(qlits_are_ortho(
         &QLit::UniformSuperpos {
             q1: Box::new(QLit::QubitTilt {
                 q: Box::new(QLit::ZeroQubit { dbg: None }),
-                angle_deg: 45.0,
+                angle_deg: 0.0,
                 dbg: None
             }),
             q2: Box::new(QLit::QubitTilt {
                 q: Box::new(QLit::OneQubit { dbg: None }),
-                angle_deg: 225.0,
+                angle_deg: 90.0,
                 dbg: None
             }),
             dbg: None
@@ -158,17 +158,40 @@ fn test_qlits_are_ortho_sym() {
         &QLit::UniformSuperpos {
             q1: Box::new(QLit::QubitTilt {
                 q: Box::new(QLit::ZeroQubit { dbg: None }),
-                angle_deg: 135.0,
+                angle_deg: 0.0,
                 dbg: None
             }),
             q2: Box::new(QLit::QubitTilt {
                 q: Box::new(QLit::OneQubit { dbg: None }),
-                angle_deg: 135.0,
+                angle_deg: 270.0,
                 dbg: None
             }),
             dbg: None
         }
     ));
+
+    // '0' + '1'@90 _|_ '0' + '1'@270
+    assert!(qlits_are_ortho(
+        &QLit::UniformSuperpos {
+            q1: Box::new(QLit::ZeroQubit { dbg: None }),
+            q2: Box::new(QLit::QubitTilt {
+                q: Box::new(QLit::OneQubit { dbg: None }),
+                angle_deg: 90.0,
+                dbg: None
+            }),
+            dbg: None
+        },
+        &QLit::UniformSuperpos {
+            q1: Box::new(QLit::ZeroQubit { dbg: None }),
+            q2: Box::new(QLit::QubitTilt {
+                q: Box::new(QLit::OneQubit { dbg: None }),
+                angle_deg: 270.0,
+                dbg: None
+            }),
+            dbg: None
+        }
+    ));
+
     // '0'@45 + '1'@225 !_|_ '0'@0 + '1'@180
     assert!(!qlits_are_ortho(
         &QLit::UniformSuperpos {

--- a/qwerty_pyrt/python/qwerty/convert_ast.py
+++ b/qwerty_pyrt/python/qwerty/convert_ast.py
@@ -603,6 +603,10 @@ class QpuVisitor(BaseVisitor):
             left = self.extract_basis_vector(node.left)
             right = self.extract_basis_vector(node.right)
             return Vector.new_vector_tensor([left, right], dbg)
+        elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.MatMult):
+            q = self.extract_basis_vector(node.left)
+            angle_deg = self.extract_float_const(node.right)
+            return Vector.new_vector_tilt(q, angle_deg, dbg)
         elif isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
             q = self.extract_basis_vector(node.operand)
             return Vector.new_vector_tilt(q, 180.0, dbg)
@@ -637,6 +641,16 @@ class QpuVisitor(BaseVisitor):
             node_name = type(node).__name__
             raise QwertySyntaxError('Unknown basis syntax {}'
                                     .format(node_name), dbg)
+
+    # TODO: expand this into extract_float_expr()
+    def extract_float_const(self, node: ast.AST) -> float:
+        if isinstance(node, ast.Constant) \
+                and isinstance(node.value, (int, float)):
+            return float(node.value)
+        else:
+            node_name = type(node).__name__
+            raise QwertySyntaxError('Unsupported float constant syntax '
+                                    + node_name, self.get_debug_loc(node))
 
     #def extract_float_expr(self, node: ast.AST):
     #    """

--- a/qwerty_pyrt/python/qwerty/tests/integ/tilt_nometa.py
+++ b/qwerty_pyrt/python/qwerty/tests/integ/tilt_nometa.py
@@ -1,0 +1,27 @@
+"""
+Some Qwerty test programs involving the tilt operator ``@``.
+"""
+
+from qwerty import *
+
+@qpu
+def kernel_p() -> bit:
+    return '0' + '1' | __MEASURE__({'0'+'1','0'+'1'@180})
+
+@qpu
+def kernel_m() -> bit:
+    return '0' + '1'@180 | __MEASURE__({'0'+'1','0'+'1'@180})
+
+@qpu
+def kernel_i() -> bit:
+    return '0' + '1'@90 | __MEASURE__({'0'+'1'@90, '0'+'1'@270})
+
+@qpu
+def kernel_j() -> bit:
+    return '0' + '1'@270 | __MEASURE__({'0'+'1'@90, '0'+'1'@270})
+
+def test(shots):
+    return (kernel_p(shots=shots),
+            kernel_m(shots=shots),
+            kernel_i(shots=shots),
+            kernel_j(shots=shots))

--- a/qwerty_pyrt/python/qwerty/tests/integration_tests.py
+++ b/qwerty_pyrt/python/qwerty/tests/integration_tests.py
@@ -74,3 +74,14 @@ class IntegrationTests(unittest.TestCase):
             {bit[1](0b1): shots},
         )
         self.assertEqual(expected_histos, teleport_nometa.test(shots))
+
+    def test_tilt_nometa(self):
+        from .integ import tilt_nometa
+        shots = 1024
+        expected_histos = (
+            {bit[1](0b0): shots},
+            {bit[1](0b1): shots},
+            {bit[1](0b0): shots},
+            {bit[1](0b1): shots},
+        )
+        self.assertEqual(expected_histos, tilt_nometa.test(shots))

--- a/qwerty_pyrt/rust/src/mlir.rs
+++ b/qwerty_pyrt/rust/src/mlir.rs
@@ -248,15 +248,20 @@ fn ast_vec_to_mlir_helper(vec: &Vector) -> (qwerty::PrimitiveBasis, qwerty::Eige
         Vector::OneVector { .. } => (qwerty::PrimitiveBasis::Z, qwerty::Eigenstate::Minus, 0.0),
 
         Vector::UniformVectorSuperpos { q1, q2, .. } => match (&**q1, &**q2) {
+            // '0' + '1' ==> 'p'
             (Vector::ZeroVector { .. }, Vector::OneVector { .. }) => {
                 (qwerty::PrimitiveBasis::X, qwerty::Eigenstate::Plus, 0.0)
             }
+
+            // '0' + '1'@180 ==> 'm'
             (Vector::ZeroVector { .. }, Vector::VectorTilt { q, angle_deg, .. })
                 if angles_are_approx_equal(*angle_deg, 180.0)
                     && matches!(**q, Vector::OneVector { .. }) =>
             {
                 (qwerty::PrimitiveBasis::X, qwerty::Eigenstate::Minus, 0.0)
             }
+
+            // '1' + '0'@180 ==> -'m'
             (Vector::OneVector { .. }, Vector::VectorTilt { q, angle_deg, .. })
                 if angles_are_approx_equal(*angle_deg, 180.0)
                     && matches!(**q, Vector::ZeroVector { .. }) =>
@@ -267,6 +272,8 @@ fn ast_vec_to_mlir_helper(vec: &Vector) -> (qwerty::PrimitiveBasis, qwerty::Eige
                     std::f64::consts::PI,
                 )
             }
+
+            // '0'@180 + '1'@180 ==> -'p'
             (
                 Vector::VectorTilt {
                     q: q1,
@@ -289,6 +296,23 @@ fn ast_vec_to_mlir_helper(vec: &Vector) -> (qwerty::PrimitiveBasis, qwerty::Eige
                     std::f64::consts::PI,
                 )
             }
+
+            // '0' + '1'@90 ==> 'i'
+            (Vector::ZeroVector { .. }, Vector::VectorTilt { q, angle_deg, .. })
+                if angles_are_approx_equal(*angle_deg, 90.0)
+                    && matches!(**q, Vector::OneVector { .. }) =>
+            {
+                (qwerty::PrimitiveBasis::Y, qwerty::Eigenstate::Plus, 0.0)
+            }
+
+            // '0' + '1'@270 ==> 'j'
+            (Vector::ZeroVector { .. }, Vector::VectorTilt { q, angle_deg, .. })
+                if angles_are_approx_equal(*angle_deg, 270.0)
+                    && matches!(**q, Vector::OneVector { .. }) =>
+            {
+                (qwerty::PrimitiveBasis::Y, qwerty::Eigenstate::Minus, 0.0)
+            }
+
             _ => todo!("nontrivial superposition {vec}"),
         },
 


### PR DESCRIPTION
Adds support for the `@` operator in `convert_ast` and the `ij` basis. Tested with a simple integration test